### PR TITLE
Minor cosmolopy based speedups

### DIFF
--- a/Evolution.py
+++ b/Evolution.py
@@ -121,6 +121,13 @@ class SourcePopulation(object):
 
     def RedshiftDistribution(self, z):
         """ can remove 4*pi becaue we just use this in a normalized way """
+        if np.ndim(z) > 0:
+            if len(z) > 1000:
+                zz = np.linspace(0., 10., 1000)
+                spl = scipy.interpolate.UnivariateSpline(zz,
+                    cosmolopy.distance.diff_comoving_volume(zz,
+                        **self.cosmology))
+                return 4 * np.pi * self.evolution(z) * spl(z)
         return 4 * np.pi * self.evolution(z) * \
             cosmolopy.distance.diff_comoving_volume(z, **self.cosmology)
 
@@ -135,7 +142,7 @@ class SourcePopulation(object):
         # Wrapper function - so that cosmolopy is only imported here.
         if np.ndim(z) > 0:
             if len(z) > 1000:
-                zz = np.linspace(0., 10., 500)
+                zz = np.linspace(0., 10., 1000)
                 spl = scipy.interpolate.UnivariateSpline(zz, 
                         cosmolopy.distance.luminosity_distance(zz, 
                             **self.cosmology))

--- a/Firesong.py
+++ b/Firesong.py
@@ -67,8 +67,7 @@ def firesong_simulation(outputdir,
     rng = np.random.RandomState(seed)
 
     redshift_bins = np.arange(zmin, zmax, zmax/float(bins))
-    RedshiftPDF = [population.RedshiftDistribution(redshift_bins[i])
-                   for i in range(0, len(redshift_bins))]
+    RedshiftPDF = population.RedshiftDistribution(redshift_bins)
     invCDF = InverseCDF(redshift_bins, RedshiftPDF)
 
     out = output_writer(outputdir, filename)

--- a/Firesong.py
+++ b/Firesong.py
@@ -34,6 +34,7 @@ def firesong_simulation(outputdir,
                         seed=None,
                         zNEAR=-1):
 
+    print("CHECKING GITHUB RELATED THING")
     if Transient:
         population = TransientSourcePopulation(cosmology,
                                                get_evolution(Evolution),


### PR DESCRIPTION
The change in Firesong.py is a straightforward replacement of list comprehension with a slightly quicker vectorized implementation. 
The change in Evolution.py is to interpolate between some redshift bins when creating the RedshiftDistribution. This speeds up this line significantly, but I guess could just be accomplished by using fewer `bins` in `firesong_simulation`, so feel free to take it or leave it!