### PR TITLE
High density speed

### DIFF
--- a/Evolution.py
+++ b/Evolution.py
@@ -197,7 +197,7 @@ class SourcePopulation(object):
         if index != 2.0:
             integral = (u_lim**(2-index)-l_lim**(2-index)) / (2-index)
         else:
-            integral = np.log(u_lim) - np.log(l_lim)
+            integral = np.log(u_lim/l_lim)
         return E0**index * integral
 
     def StandardCandleSources(self, fluxnorm, density, zmax, index, z0=1.):
@@ -378,7 +378,7 @@ class LuminosityEvolution(object):
         if index != 2.0:
             integral = (u_lim**(2-index)-l_lim**(2-index)) / (2-index)
         else:
-            integral = np.log(u_lim) - np.log(l_lim)
+            integral = np.log(u_lim/l_lim)
         return E0**index * integral
 
 class HardingAbazajian(LuminosityEvolution):

--- a/Evolution.py
+++ b/Evolution.py
@@ -192,12 +192,11 @@ class SourcePopulation(object):
 
     def EnergyIntegral(self, index, emin, emax, z=1, E0=1e5):
         """ integal_{emin/(1+z)}^{emax/(1+z)} E*(E/E0)^(-index) dE """
-        l_lim = emin/(1.+z)
-        u_lim = emax/(1.+z)
         if index != 2.0:
-            integral = (u_lim**(2-index)-l_lim**(2-index)) / (2-index)
+            denom = (1+z)**(index-2)
+            integral = denom * (emin**(2-index)-emax**(2-index)) / (2-index)
         else:
-            integral = np.log(u_lim/l_lim)
+            integral = np.ones_like(z) * np.log(emax/emin)
         return E0**index * integral
 
     def StandardCandleSources(self, fluxnorm, density, zmax, index, z0=1.):
@@ -373,12 +372,11 @@ class LuminosityEvolution(object):
 
     def EnergyIntegral(self, index, emin, emax, z=1, E0=1e5):
         """ integal_{emin/(1+z)}^{emax/(1+z)} E*(E/E0)^(-index) dE """
-        l_lim = emin/(1.+z)
-        u_lim = emax/(1.+z)
         if index != 2.0:
-            integral = (u_lim**(2-index)-l_lim**(2-index)) / (2-index)
+            denom = (1+z)**(index-2)
+            integral = denom * (emin**(2-index)-emax**(2-index)) / (2-index)
         else:
-            integral = np.log(u_lim/l_lim)
+            integral = np.ones_like(z) * np.log(emax/emin)
         return E0**index * integral
 
 class HardingAbazajian(LuminosityEvolution):

--- a/sampling.py
+++ b/sampling.py
@@ -21,8 +21,9 @@ class InverseCDF(object):
 
         self.rng = np.random.RandomState(seed)
         cdf = np.cumsum(pdf)/np.sum(pdf)
-        mask = np.diff(cdf) > 0
-        self.invCDF = interp1d(cdf[1:][mask], x[1:][mask] + (x[1]-x[0])/2., kind='linear')
+        mask = np.diff(cdf, prepend=0) > 0
+        self.invCDF = interp1d(cdf[mask], x[mask], kind='linear',
+                               bounds_error=False, fill_value='extrapolate')
 
     def __call__(self, x):
         x = np.atleast_1d(x)

--- a/sampling.py
+++ b/sampling.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.interpolate import UnivariateSpline
+from scipy.interpolate import interp1d
 
 
 class InverseCDF(object):
@@ -22,11 +22,12 @@ class InverseCDF(object):
         self.rng = np.random.RandomState(seed)
         cdf = np.cumsum(pdf)/np.sum(pdf)
         mask = np.diff(cdf) > 0
-        self.invCDF = UnivariateSpline(cdf[1:][mask], x[1:][mask] + (x[1]-x[0])/2., k=1, s=0)
+        self.invCDF = interp1d(cdf[1:][mask], x[1:][mask] + (x[1]-x[0])/2., kind='linear')
 
     def __call__(self, x):
+        x = np.atleast_1d(x)
         """ Returns the inverse CDF at point(s) x """
-        if any(np.atleast_1d(x) < 0) or any(np.atleast_1d(x) > 1):
+        if any(x < 0) or any(x > 1):
             raise ValueError("x out of bounds. x has to be in range 0..1")
         return self.invCDF(x)
 


### PR DESCRIPTION
Replaces the InverseCDF's internal UnivariateSpline with scipy's interp1d in order to reduce the number of calculations needed for an evaluation, dropping the processing time for high densities by around 70%. This works towards improving the issue raised in #15.

Also fixes #19 by changing InverseCDF's internal code to assume that the cdf values received correspond exactly to the given redshifts and not to averages over redshift bins.