### PR TITLE
Fix the test_sampling.py test failures

### DIFF
--- a/sampling.py
+++ b/sampling.py
@@ -21,9 +21,17 @@ class InverseCDF(object):
 
         self.rng = np.random.RandomState(seed)
         cdf = np.cumsum(pdf)/np.sum(pdf)
-        mask = np.diff(cdf, prepend=0) > 0
+
+        # Pad the arrays to ensure the cdf starts/ends at the right points
+        cdf = np.concatenate([[0,], cdf, [1,]])
+        x = np.concatenate([[x.min()-np.finfo(x.dtype).eps,],
+                            x,
+                            [x.max()+np.finfo(x.dtype).eps,]])
+
+        # Also prepend a 0 here to ensure the shape stays the same
+        mask = np.diff(cdf, prepend=0) >= 0
         self.invCDF = interp1d(cdf[mask], x[mask], kind='linear',
-                               bounds_error=False, fill_value='extrapolate')
+                               bounds_error=False, fill_value=(x.min(), x.max()))
 
     def __call__(self, x):
         x = np.atleast_1d(x)

--- a/test_sampling.py
+++ b/test_sampling.py
@@ -13,6 +13,7 @@ import unittest
 import sampling
 import numpy as np
 
+from scipy.stats import truncnorm
 
 class TestInverseCDF(unittest.TestCase):
     """ Tests get_evolution function, Evolution class and
@@ -31,9 +32,16 @@ class TestInverseCDF(unittest.TestCase):
 
     def setUp(self):
         "before each test"
-        x = np.linspace(0, 100., 101)
-        pdf = np.exp(-0.5*((x-50.)/5.)**2)
+        mean, sigma = 50, 5
+        x = np.linspace(0, 100., 10001).astype(np.float32)
+        
+        bounds = [(x.min() - mean) / sigma,
+                  (x.max() - mean) / sigma]
+        self.truncnorm = truncnorm(bounds[0], bounds[1], loc=50, scale=5)
+
+        pdf = self.truncnorm.pdf(x)
         self.invCDF = sampling.InverseCDF(x, pdf, seed=1)
+
 
     def tearDown(self):
         "after each test"
@@ -42,9 +50,9 @@ class TestInverseCDF(unittest.TestCase):
     ### tests start here ###
 
     def test_InverseCDF_evaluation(self):
-        self.assertTrue(self.invCDF(1.0) <= 100)
-        self.assertTrue(self.invCDF(0.0) >= 0)
-        self.assertAlmostEqual(self.invCDF(0.5), 50)
+        self.assertAlmostEqual(self.invCDF(1.0)[0], self.truncnorm.ppf(1.0), 2)
+        self.assertAlmostEqual(self.invCDF(0.0)[0], self.truncnorm.ppf(0.0), 2)
+        self.assertAlmostEqual(self.invCDF(0.5)[0], self.truncnorm.ppf(0.5), 2)
 
     def test_InverseCDF_evaluation_out_of_bound(self):
         with self.assertRaises(ValueError):
@@ -53,15 +61,15 @@ class TestInverseCDF(unittest.TestCase):
             self.invCDF(-0.1)
 
     def test_random_default(self):
-        self.assertEqual(self.invCDF.sample(), 48.949116836587841)
+        self.assertEqual(self.invCDF.sample(), 52.914028811506654)
 
     def test_random_given_N_1(self):
-        self.assertEqual(self.invCDF.sample(N=1), 48.949116836587841)
+        self.assertEqual(self.invCDF.sample(N=1), 52.914028811506654)
 
     def test_random_given_N_5(self):
         x = self.invCDF.sample(N=5)
         self.assertEqual(len(x), 5)
-        self.assertEqual(x[0], 48.949116836587841)
+        self.assertEqual(x[0], 43.362544905234685)
         self.assertNotEqual(x[0], x[1])
 
     def test_random_wrong_parameter(self):


### PR DESCRIPTION
The test_sampling.py relied on numbers found from the buggy InvCDF sampling before the fix in #19 . This updates the test with new numbers and replaces a hand-crafted truncated gaussian distribution in the test with an implementation from scipy, which directly gives the cdf values we want to test against.

In order to better ensure that things are working correctly, adding is also added to the InvCDF function. This ensures that the values at the edges - CDF values of 0 and 1 - return the right thing. Before, the edges were a little bit dodgy and could return values outside of [0,1].