### PR TITLE
Enhancement/flux pdf update

### DIFF
--- a/Evolution.py
+++ b/Evolution.py
@@ -53,6 +53,9 @@ class NoEvolution(Evolution):
     def parametrization(self, x):
         return 1.
 
+    def __str__(self):
+        return "No Evolution"
+
 
 class HopkinsBeacom2006StarFormationRate(Evolution):
     """ 
@@ -94,6 +97,9 @@ class HopkinsBeacom2006StarFormationRate(Evolution):
         if len(result) == 1:
             return result.item()
         return result
+
+    def __str__(self):
+        return "Hopkins and Beacom (2006)"
 
 class YukselEtAl2008StarFormationRate(Evolution):
     r""" 
@@ -139,6 +145,9 @@ class YukselEtAl2008StarFormationRate(Evolution):
         return r0 * (x**(a*eta) + (x/B)**(b*eta) +
                      (x/C)**(c*eta))**(1./eta)
 
+    def __str__(self):
+            return "Yuksel et al. (2008)"
+
 class CandelsClash2015SNRate(Evolution):
     r"""
     This is the implied SFR from Goods/Candels/Clash (2015)
@@ -172,6 +181,9 @@ class CandelsClash2015SNRate(Evolution):
         d = 6.1
         density = a*(x**c) / (1. + ( x / b)**d )
         return density
+    
+    def __str__(self):
+        return "Strolger et al. (2015)"
 
 
 class MadauDickinson2014CSFH(Evolution):
@@ -205,6 +217,9 @@ class MadauDickinson2014CSFH(Evolution):
         d = 5.6
         density = a*(x**b) / (1. + (x/c)**d ) 
         return density
+
+    def __str__(self):
+        return "Madau and Dickinson (2014)"
 
 
 class SourcePopulation(object):
@@ -841,6 +856,9 @@ class HardingAbazajian(LuminosityEvolution):
                arXiv:1012.1247
                arXiv:0308140
     """
+    def __str__(self):
+        return "Harding and Abazajian (2012)"
+        
     def LF(self, L, z):
         """
         Luminosity function based on X-ray AGN

--- a/Luminosity.py
+++ b/Luminosity.py
@@ -89,7 +89,7 @@ class LG_LuminosityFunction(LuminosityFunction):
         """ Log Normal Luminosity function.
 
         Args:
-            - mean luminosity (Not not median and not log(mean))
+            - mean luminosity (Not median and not log(mean))
             - width in dex (width in log10)
 
         Note:
@@ -126,8 +126,7 @@ class LG_LuminosityFunction(LuminosityFunction):
             $$ \frac{1}{x\sigma \sqrt{2\pi}} \times 
             \exp{-\frac{(\ln(x)-\mu)^2}{2\sigma^1}}$$
         """
-        return np.exp(self.mu) * \
-            lognorm.pdf(lumi, s=self.sigma, scale=np.exp(self.mu))
+        return lognorm.pdf(lumi, s=self.sigma, scale=np.exp(self.mu))
 
     def cdf(self, lumi):
         r""" Gives the value of the CDF at lumi.


### PR DESCRIPTION
A few things:
* FluxPDF was really slow, first I removed the loops but maintained the same implementation
* Fixed the standard candle bug that Ignacio found and Rene suggested how to fix (https://github.com/icecube/FIRESONG/issues/30)
* Integration wasn't properly normalized for non-SC luminosity functions, I had to change the integral to be in linear space and fix the PDF normalization in Luminosity
* Increased the number of luminosity bins (more precise)
* Unrelated: added __str__ methods to Evolution.py

To make sure that everything was working properly, I simulated a SC population with FIRESONG.py (histogram) and compared this to the PDF I get from FluxPDF using a SC (blue) or a LG with narrow width (orange) and everything looks good. Plot attached below. This should close https://github.com/icecube/FIRESONG/issues/30 and https://github.com/icecube/FIRESONG/issues/15 as we can just suggest users use Theo's FluxPDF for high densities

![image](https://user-images.githubusercontent.com/27740114/109830457-20fb8500-7c04-11eb-8c83-8259555f4446.png)
