### PR TITLE
Update/update cosmo

### DIFF
--- a/.github/workflows/test-firesong.yml
+++ b/.github/workflows/test-firesong.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - feature/pip-installable
       - base
+      - update/update-cosmo
 
 jobs:
   unittest_and_coverage:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ the exploration of the luminosity vs. local density plane (aka
 Kowalski plot).
 
 More examples are included in the `notebooks` directory.
+`Jupyter notebook` and `matplotlib` are required to run the examples.
 
 # Tests
 All unittest could be run by

--- a/firesong/distance.py
+++ b/firesong/distance.py
@@ -4,16 +4,25 @@
 Distance calculation substitute for cosmolopy
 All formula used are from 
 https://arxiv.org/pdf/astro-ph/9905116.pdf
-
-Default in all functions are using Planck15
 '''
 import numpy as np
 from scipy.integrate import quad
 
 class cosmo_distance(object):
     def __init__(self, **cosmology):
+        '''
+        To initiate, cosmological parameters must be supplied
+        in the form of a dictionary with the following keys
+        {'omega_M_0', 'omega_lambda_0', 'h'}
+
+        Input:
+        **kwargs = {'omega_M_0', 'omega_lambda_0', 'h'}
+        '''
         self.c = 299792458 # speed of light in ms^-1
         # initialize class
+        for k in ['omega_M_0', 'omega_lambda_0', 'h']:
+            if k not in cosmology.keys():
+                raise Exception('Cosmological parameter {} must be supplied'.format(k))
         self.load_param(**cosmology)
 
     def load_param(self, **cosmology):
@@ -22,10 +31,10 @@ class cosmo_distance(object):
         density of curvature is defined as 1-om0-ode
         unless otherwise specified.
         '''
-        self.om0 = cosmology.get('omega_M_0', 0.315)
-        self.ode = cosmology.get('omega_lambda_0', 0.685)
+        self.om0 = cosmology.get('omega_M_0')
+        self.ode = cosmology.get('omega_lambda_0')
         self.ok0 = cosmology.get('omega_k_0', 1-self.om0-self.ode)
-        self.h = cosmology.get('h', 0.674)
+        self.h = cosmology.get('h')
 
         # Hubble distance D_h (unit=Mpc)
         self.D_h = self.c/1000./100./self.h
@@ -64,6 +73,7 @@ class cosmo_distance(object):
 
         '''
         z = np.atleast_1d(z)
+        # epsabs can be tweaked to achieve higher precision
         D_c = np.array([self.D_h*quad(lambda x:1./self.E(x), 
                                  z_0, lim, epsabs=1.e-5)[0] for lim in z])
         # return a float if only one redshift

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 coverage==5.4
 numpy==1.16.6
 scipy==1.2.3
-matplotlib==3.2.2
-jupyter==4.6.3

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setuptools.setup(
     'numpy>=1.16.6',
     'scipy>=1.2.3',
     'matplotlib',
-    'jupyter']
+    'jupyter>=3.0']
 )

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,5 @@ setuptools.setup(
     'coverage>=5.4',
     'numpy>=1.16.6',
     'scipy>=1.2.3',
-    'matplotlib',
-    'jupyter>=3.0']
+    ]
 )


### PR DESCRIPTION
1. `cosmo_distance` will not provide default values for cosmological parameters
2. specified in README that `jupyter notebook` and `matplotlib` are required to run the examples,  but not in setup.py or requirements.txt. I think these two installs are not really necessary to run the FIRESONG, so should be left for users to decide.