### PR TITLE
typos and cleanup

### DIFF
--- a/firesong/Evolution.py
+++ b/firesong/Evolution.py
@@ -648,7 +648,7 @@ def get_LEvolution(le_model, lmin, lmax):
 
     Args:
         le_model (str): Name of luminosity-evolution model, only supported
-            optioin is "HA2014BL"
+            option is "HA2014BL"
         lmin (float): log10 of Minimum luminosity considered in erg/s
         lmax (float): log10 of Maximum luminosity considered in erg/s
 
@@ -862,7 +862,7 @@ class HardingAbazajian(LuminosityEvolution):
 
     Reference: arXiv:1206.4734
                arXiv:1012.1247
-               arXiv:0308140
+               arXiv:astro-ph/0308140
     """
     def __str__(self):
         return "Harding and Abazajian (2012)"

--- a/notebooks/Legend Example.ipynb
+++ b/notebooks/Legend Example.ipynb
@@ -15,6 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
@@ -28,8 +29,8 @@
    "metadata": {},
    "source": [
     "# LEGEND\n",
-    "For some sources, their distribution depends on both redshift and the soure luminosity. Legend is designed for generating this type of sources.\n",
-    "I will use the Luminosity-Dependent-Density-Evolution (LDDE) model of Blazars (https://arxiv.org/pdf/1012.1247.pdf) (https://arxiv.org/pdf/1206.4734.pdf), which will be referred as the HA2014 model, as an example. This model has been implmented in Firesong."
+    "For some sources, their distribution depends on both redshift and the source luminosity. Legend is designed for generating this type of sources.\n",
+    "I will use the Luminosity-Dependent-Density-Evolution (LDDE) model of Blazars ([arXiv:1012.1247](https://arxiv.org/pdf/1012.1247.pdf), [arXiv:1206.4734](https://arxiv.org/pdf/1206.4734.pdf)), which will be referred to as the HA2014 model, as an example. This model has been implemented in Firesong."
    ]
   },
   {


### PR DESCRIPTION
Just a few minor fixes.

One other thing I noticed while going through the LEGEND notebook: You refer to the model as "HA2014" (and "HA2014BL" in the code), but the papers it’s based on are from 2012 and the `__str__` method of that class also returns "Harding and Abazajian (2012)". Is that a mix-up or am I missing something?