### PR TITLE
Blazar powerlaw alt

### DIFF
--- a/.github/workflows/test-firesong.yml
+++ b/.github/workflows/test-firesong.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/firesong/Evolution.py
+++ b/firesong/Evolution.py
@@ -19,7 +19,7 @@ from firesong.distance import cosmo_distance
 #cosmology = {'omega_M_0': 0.308, 'omega_lambda_0': 0.692, 'h': 0.678}
 cosmology = {'omega_M_0': 0.315, 'omega_lambda_0': 0.685, 'h': 0.674}
 
-def get_evolution(evol):
+def get_evolution(evol, **kwargs):
     """
     Get specific evolution model
 
@@ -35,13 +35,14 @@ def get_evolution(evol):
                   "HB2006SFR": HopkinsBeacom2006StarFormationRate,
                   "YMKBH2008SFR": YukselEtAl2008StarFormationRate,
                   "CC2015SNR": CandelsClash2015SNRate,
-                  "MD2014SFR": MadauDickinson2014CSFH
+                  "MD2014SFR": MadauDickinson2014CSFH,
+                  "PowerLaw": PowerLaw,
                   }
     if not evol in list(evolutions.keys()):
         raise NotImplementedError("Source evolution " +
                                   evol + " not implemented.")
+    return evolutions[evol](**kwargs)
 
-    return evolutions[evol]()
 
 class Evolution(object):
     """
@@ -55,6 +56,20 @@ class Evolution(object):
 
     def __call__(self, z):
         return self.parametrization(np.log10(1.+z))
+
+class PowerLaw(Evolution):
+    """
+    Power law with extinction term in the form (1 + z)^k * exp(z/xi)
+    """
+    def __init__(self, k, xi):
+        self.k = k
+        self.xi = xi
+
+    def parametrization(self, z):
+        return (1 + z)**self.k * np.exp(z/self.xi)
+
+    def __call__(self, z):
+        return self.parametrization(z)
 
 
 class NoEvolution(Evolution):
@@ -283,7 +298,6 @@ class MadauDickinson2014CSFH(Evolution):
 
     def __str__(self):
         return "Madau and Dickinson (2014)"
-
 
 class SourcePopulation(object):
     """

--- a/firesong/Evolution.py
+++ b/firesong/Evolution.py
@@ -377,7 +377,7 @@ class SourcePopulation(object):
         if np.ndim(z) > 0:
             if len(z) > 1000:
                 zz = np.linspace(0., 10., 500)
-                spl = scipy.interpolate.UnivariateSpline(zz, 
+                spl = scipy.interpolate.interp1d(zz, 
                         self.cosmology.luminosity_distance(zz))
                 return spl(z)
         return self.cosmology.luminosity_distance(z)
@@ -780,7 +780,7 @@ class LuminosityEvolution(object):
         if np.ndim(z) > 0:
             if len(z) > 1000:
                 zz = np.linspace(0., 10., 500)
-                spl = scipy.interpolate.UnivariateSpline(zz,
+                spl = scipy.interpolate.interp1d(zz,
                         self.cosmology.luminosity_distance(zz))
                 return spl(z)
         return self.cosmology.luminosity_distance(z)

--- a/firesong/Firesong.py
+++ b/firesong/Firesong.py
@@ -29,6 +29,7 @@ def firesong_simulation(outputdir,
                         fluxnorm=1.44e-8,
                         index=2.28,
                         LF="SC",
+                        LF_conf = {},
                         sigma=1.0,
                         luminosity=0.0,
                         Gammaflux=False,
@@ -102,7 +103,7 @@ def firesong_simulation(outputdir,
                                                          emax=emax)
 
     luminosity_function = get_LuminosityFunction(luminosity, LF=LF,
-                                                 sigma=sigma)
+                                                 sigma=sigma, **LF_conf)
 
     delta_gamma = 2-index
     if verbose:

--- a/firesong/FluxPDF.py
+++ b/firesong/FluxPDF.py
@@ -26,14 +26,14 @@ def flux_pdf(outputdir,
              fluxnorm=1.44e-8,
              index=2.28,
              LF="SC",
-             sigma=1.0,
              luminosity=0.0,
              emin=1e4,
              emax=1e7,
              LumMin=1e45, LumMax=1e54, nLbins=500,
              logFMin=-10, logFMax=6, nFluxBins=200,
              with_dFdz=False,
-             verbose=True):
+             verbose=True,
+             **kwargs):
     """
     Simulate a universe of neutrino sources and calculate the PDF of fluxes
 
@@ -106,7 +106,7 @@ def flux_pdf(outputdir,
                                                          emax=emax)
 
     luminosity_function = get_LuminosityFunction(luminosity, LF=LF,
-                                                 sigma=sigma)
+                                                 **kwargs)
 
     delta_gamma = 2-index
     if verbose:

--- a/firesong/Luminosity.py
+++ b/firesong/Luminosity.py
@@ -8,14 +8,13 @@ from scipy.stats import lognorm
 
 
 class LuminosityFunction(object):
-    """Luminosity Function class.
-    """
+    """Luminosity Function class."""
 
     def __init__(self, mean_luminosity):
         """Luminosity function.
 
         Args:
-            - mean luminosity (Not not median and not log(mean))
+            - mean luminosity (Not median and not log(mean))
         """
         self.mean = mean_luminosity
 
@@ -30,12 +29,12 @@ class LuminosityFunction(object):
 
 
 class SC_LuminosityFunction(LuminosityFunction):
-    """ Standard Candle Luminosity functions.
+    """Standard Candle Luminosity functions.
     All sources have same luminosity.
     """
 
     def sample_distribution(self, nsources=None, rng=None):
-        """ Samples from the Luminosity Function nsource times
+        """Samples from the Luminosity Function nsource times
 
         Args:
             number of sources
@@ -43,7 +42,7 @@ class SC_LuminosityFunction(LuminosityFunction):
         return self.mean
 
     def pdf(self, lumi):
-        """ Gives the value of the PDF at lumi.
+        """Gives the value of the PDF at lumi.
 
         Args:
             lumi: float or array-like, point where PDF is evaluated.
@@ -54,17 +53,18 @@ class SC_LuminosityFunction(LuminosityFunction):
         """
         lumi = np.atleast_1d(lumi)
         if len(lumi) < 2:
-            raise NotImplementedError("""This is a delta function.
+            raise NotImplementedError(
+                """This is a delta function.
                 PDF not defined.
                 We only can return something meaning full for a nice array.
-                """)
+                """
+            )
         pdf = np.zeros_like(lumi)
-        pdf[:-1][np.logical_and(self.mean > lumi[:-1],
-                 self.mean < lumi[1:])] = 1
+        pdf[:-1][np.logical_and(self.mean > lumi[:-1], self.mean < lumi[1:])] = 1
         return pdf
 
     def cdf(self, lumi):
-        """ Gives the value of the CDF at lumi.
+        """Gives the value of the CDF at lumi.
 
         Args:
             lumi: float or array-like, point where CDF is evaluated.
@@ -76,17 +76,16 @@ class SC_LuminosityFunction(LuminosityFunction):
         """
         lumi = np.atleast_1d(lumi)
         cdf = np.zeros_like(lumi)
-        cdf[lumi == self.mean] = .5
-        cdf[lumi > self.mean] = 1.
+        cdf[lumi == self.mean] = 0.5
+        cdf[lumi > self.mean] = 1.0
         if len(lumi) == 1:
             return cdf[0]
         return cdf
 
 
 class LG_LuminosityFunction(LuminosityFunction):
-
     def __init__(self, mean_luminosity, width):
-        """ Log Normal Luminosity function.
+        """Log Normal Luminosity function.
 
         Args:
             - mean luminosity (Not median and not log(mean))
@@ -99,89 +98,10 @@ class LG_LuminosityFunction(LuminosityFunction):
             sigma = log(10^width)
         """
         self.mean = mean_luminosity
-        self.width = width                     # width is given in log10
-        self.logmean = np.log(self.mean)       # log mean luminosity
-        self.sigma = np.log(10**self.width)    # sigma is given in ln
-        self.mu = self.logmean-self.sigma**2./2.  # log median luminosity
-
-    def sample_distribution(self, nsources=None, rng=None):
-        """ Samples from the Luminosity Function nsource times
-
-        Args:
-            number of sources
-        """
-        if rng is None:
-            rng = np.random.RandomState()
-        return rng.lognormal(self.mu, self.sigma, nsources)
-
-    def pdf(self, lumi):
-        r""" Gives the value of the PDF at lumi.
-
-        Args:
-            lumi: float or array-like, point where PDF is evaluated.
-
-        Notes:
-            PDF given by:
-
-            $$ \frac{1}{x\sigma \sqrt{2\pi}} \times 
-            \exp{-\frac{(\ln(x)-\mu)^2}{2\sigma^1}}$$
-        """
-        return lognorm.pdf(lumi, s=self.sigma, scale=np.exp(self.mu))
-
-    def cdf(self, lumi):
-        r""" Gives the value of the CDF at lumi.
-
-        Args:
-            lumi: float or array-like, point where CDF is evaluated.
-
-        Notes:
-            CDF given by:
-
-            $$ \frac{1}{2} + \frac{1}{2} \times 
-            \mathrm{erf}\left( \frac{(\ln(x)-\mu)^2}{\sqrt{2}\sigma}\right)$$
-        """
-        return lognorm.cdf(lumi, s=self.sigma, scale=np.exp(self.mu))
-
-
-class PL_LuminosityFunction(LuminosityFunction):
-    r""" Power-law distribution defined between x_min and x_max.
-
-        PDF:
-        $$\frac{1-\alpha}{x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}\times
-        x^{-\alpha}$$
-
-        CDF:
-        $$\frac{x^{1-\alpha}-x_{min}^{1-\alpha}}
-        {x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}$$
-
-        inv.CDF:
-        $$ P^{-1}(x) = (x_{min}^{\beta} + (x_{max}^{\beta}
-         -x_{min}^{\beta})*x)^{1/\beta}$$
-
-        Formulars from: http://up-rs-esp.github.io/bpl/
-        and: Clauset, A., Shalizi, C. R., Newman, M. E. J.
-        "Power-law Distributions in Empirical Data".
-        SFI Working Paper: 2007-12-049 (2007)  arxiv:0706.1062
-    """
-
-    def __init__(self, mean_luminosity, index, width):
-        """ Power-law distribution defined between x_min and x_max.
-        x_min and x_max are calculated from mean and width of distribution.
-
-        Note:
-            f_mean ~= width*ln(10)*F_min,          index = -2
-            f_mean ~= (index+1)/(index+2)*F_min    index < -2
-        """
-        self.mean = mean_luminosity
-        self.index = index
-        self.width = width
-
-        if self.index == -2:
-            self.Fmin = self.mean / (self.width*np.log(10))
-        else:
-            self.Fmin = (self.index+2.)/(self.index+1.)*self.mean
-
-        self.Fmax = self.Fmin*10**self.width
+        self.width = width  # width is given in log10
+        self.logmean = np.log(self.mean)  # log mean luminosity
+        self.sigma = np.log(10**self.width)  # sigma is given in ln
+        self.mu = self.logmean - self.sigma**2.0 / 2.0  # log median luminosity
 
     def sample_distribution(self, nsources=None, rng=None):
         """Samples from the Luminosity Function nsource times
@@ -191,10 +111,127 @@ class PL_LuminosityFunction(LuminosityFunction):
         """
         if rng is None:
             rng = np.random.RandomState()
-        x = rng.uniform(0, 1, nsources)
-        beta = (1.+self.index)
-        return (self.Fmin**beta + (self.Fmax**beta -
-                                   self.Fmin**beta)*x)**(1./beta)
+        return rng.lognormal(self.mu, self.sigma, nsources)
+
+    def pdf(self, lumi):
+        r"""Gives the value of the PDF at lumi.
+
+        Args:
+            lumi: float or array-like, point where PDF is evaluated.
+
+        Notes:
+            PDF given by:
+
+            $$ \frac{1}{x\sigma \sqrt{2\pi}} \times
+            \exp{-\frac{(\ln(x)-\mu)^2}{2\sigma^1}}$$
+        """
+        return lognorm.pdf(lumi, s=self.sigma, scale=np.exp(self.mu))
+
+    def cdf(self, lumi):
+        r"""Gives the value of the CDF at lumi.
+
+        Args:
+            lumi: float or array-like, point where CDF is evaluated.
+
+        Notes:
+            CDF given by:
+
+            $$ \frac{1}{2} + \frac{1}{2} \times
+            \mathrm{erf}\left( \frac{(\ln(x)-\mu)^2}{\sqrt{2}\sigma}\right)$$
+        """
+        return lognorm.cdf(lumi, s=self.sigma, scale=np.exp(self.mu))
+
+
+class BoundedPowerLaw:
+    r"""Defines a power law with arbitrary scale in the form:
+
+    $$ f(x) = A x^{-\alpha} $$
+
+    Args:
+        - A : float, scale factor
+        - alpha : float, power law index
+        - x0 : float, lower bound of the power law
+        - x1 : float, upper bound of the power law
+    """
+
+    def __init__(self, A, alpha, x0, x1):
+        self.A = A
+        self.alpha = alpha
+        self.beta = 1 - alpha
+        self.x0 = x0
+        self.x1 = x1
+        self.integral = self._F(self.x1) - self._F(self.x0)
+
+    def _f(self, x):
+        """Unbounded power law"""
+        return self.A * x ** (-self.alpha)
+
+    def f(self, x):
+        """Bounded power law"""
+        return np.piecewise(
+            x, [x < self.x0, x >= self.x1], [0, 0, lambda x: self._f(x)]
+        )
+
+    def _F(self, x):
+        """Unbounded indefinite integral"""
+        return self.A * x**self.beta / self.beta
+
+    def F(self, x):
+        """Definite integral [x0, x]"""
+        return np.piecewise(
+            x,
+            [x < self.x0, x > self.x1],
+            [0, self.integral, lambda x: self._F(x) - self._F(self.x0)],
+        )
+
+    def inv_F(self, F):
+        """Inverse of function of F"""
+        return (F * (self.beta / self.A) + self.x0**self.beta) ** (1 / self.beta)
+
+
+class PL_LuminosityFunction(LuminosityFunction):
+    r"""Power-law distribution defined between Lmin and Lmax.
+
+    PDF:
+    $$\frac{1-\alpha}{x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}\times
+    x^{-\alpha}$$
+
+    CDF:
+    $$\frac{x^{1-\alpha}-x_{min}^{1-\alpha}}
+    {x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}$$
+
+    inv.CDF:
+    $$ P^{-1}(x) = (x_{min}^{\beta} + (x_{max}^{\beta}
+     -x_{min}^{\beta})*x)^{1/\beta}$$
+
+    Formulars from: http://up-rs-esp.github.io/bpl/
+    and: Clauset, A., Shalizi, C. R., Newman, M. E. J.
+    "Power-law Distributions in Empirical Data".
+    SFI Working Paper: 2007-12-049 (2007)  arxiv:0706.1062
+    """
+
+    def __init__(self, Lmin, Lmax, alpha):
+        """Power-law distribution defined between x_min and x_max.
+        x_min and x_max are calculated from mean and width of distribution.
+
+        Note:
+            f_mean ~= width*ln(10)*F_min,          index = -2
+            f_mean ~= (index+1)/(index+2)*F_min    index < -2
+        """
+        beta = 1 - alpha
+        D = Lmax**beta - Lmin**beta
+        self.PL = BoundedPowerLaw(A=beta / D, alpha=alpha, x0=Lmin, x1=Lmax)
+
+    def sample_distribution(self, nsources, rng=None):
+        """Samples from the Luminosity Function nsource times
+
+        Args:
+            number of sources
+        """
+        if rng is None:
+            rng = np.random.RandomState()
+        F = rng.uniform(0, 1, nsources)
+        return self.inv_cdf(F)
 
     def pdf(self, lumi):
         r"""Gives the value of the PDF at lumi.
@@ -207,12 +244,7 @@ class PL_LuminosityFunction(LuminosityFunction):
             $$\frac{1-\alpha}{x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}
             \times x^{-\alpha}$$
         """
-
-        norm = (1+self.index)/(self.Fmax**(1+self.index) -
-                               self.Fmin**(1+self.index))
-        pdf = norm*lumi**self.index
-        pdf[np.logical_or(lumi < self.Fmin, lumi > self.Fmax)] = 0
-        return pdf
+        return self.PL.f(lumi)
 
     def cdf(self, lumi):
         r"""Gives the value of the CDF at lumi.
@@ -225,33 +257,56 @@ class PL_LuminosityFunction(LuminosityFunction):
             $$\frac{x^{1-\alpha}-x_{min}^{1-\alpha}}
             {x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}$$
         """
-        return (lumi**(1+self.index) - self.Fmin**(1+self.index)) / \
-               ((self.Fmax**(1+self.index) - self.Fmin**(1+self.index)))
+        return self.PL.F(lumi)
+
+    def inv_cdf(self, F):
+        """
+        Gives the inverse of the CDF at F
+        """
+        return self.PL.inv_F(F)
 
 
-def get_LuminosityFunction(mean_luminosity, LF, **kwargs):
-    """Returns a Luminosity Function based on an abbreviation.
-    Known abbreviations are:
-        - SC - Standard Candle
-        - LG - Log-Normal
-        - PL - Power-Law
-
-    Args:
-        - options: Namespace with LF and needed parameters to
-                   construct luminosity function.
-        - mean_luminosity: mean luminosity.
-
-    Raises 'NotImplementedError' for unknown abbreviation.
+class BPL_LuminosityFunction(LuminosityFunction):
+    """
+    Broken power law consisting defined between Lmin and Lmax, consisting of two power laws joining at Lbreak.
     """
 
-    if LF == "SC":
-        return SC_LuminosityFunction(mean_luminosity)
-    if LF == "LG":
-        return LG_LuminosityFunction(mean_luminosity,
-                                     kwargs["sigma"])
-    if LF == "PL":
-        return PL_LuminosityFunction(mean_luminosity,
-                                     kwargs["index"],
-                                     kwargs["sigma"])
-    raise NotImplementedError("The luminosity function " +
-                              LF + " is not implemented.")
+    def __init__(self, alpha1, alpha2, Lmin, Lbreak, Lmax):
+        # auxiliary exponents
+        beta1 = 1 - alpha1
+        beta2 = 1 - alpha2
+        delta = alpha2 - alpha1
+
+        # normalisation factors
+        D_ab1 = Lbreak**beta1 - Lmin**beta1
+        D_ab2 = Lmax**beta2 - Lbreak**beta2
+
+        # scale factors for power laws
+        # calculated from conditions A1 + A2 = 1 and pdf1(Lbreak) = pdf2(Lbreak)
+        A1 = 1 / (D_ab1 / beta1 + Lbreak**delta * D_ab2 / beta2)
+        A2 = A1 * Lbreak**delta
+
+        self.PL1 = BoundedPowerLaw(A=A1, alpha=alpha1, x0=Lmin, x1=Lbreak)
+        self.PL2 = BoundedPowerLaw(A=A2, alpha=alpha2, x0=Lbreak, x1=Lmax)
+
+    def sample_distribution(self, nsources, rng=None):
+        if rng is None:
+            rng = np.random.RandomState()
+        F = rng.uniform(0, 1, nsources)
+        return self.inv_cdf(F)
+
+    def pdf(self, lumi):
+        return self.PL1.f(lumi) + self.PL2.f(lumi)
+
+    def cdf(self, lumi):
+        return self.PL1.F(lumi) + self.PL2.F(lumi)
+
+    def inv_cdf(self, F):
+        return np.piecewise(
+            F,
+            [F <= self.PL1.integral, np.logical_and(F > self.PL1.integral, F < 1)],
+            [
+                lambda F: self.PL1.inv_F(F),
+                lambda F: self.PL2.inv_F(F - self.PL1.integral),
+            ],
+        )

--- a/firesong/Luminosity.py
+++ b/firesong/Luminosity.py
@@ -10,8 +10,7 @@ from scipy.stats import lognorm
 class LuminosityFunction(object):
     """Luminosity Function class.
     """
-
-    def __init__(self):
+    def __init__(self, mean_luminosity):
         """Luminosity function.
         """
         pass
@@ -30,6 +29,8 @@ class SC_LuminosityFunction(LuminosityFunction):
     """ Standard Candle Luminosity functions.
     All sources have same luminosity.
     """
+    def __init__(self, mean_luminosity):
+        self.mean = mean_luminosity
 
     def sample_distribution(self, nsources=None, rng=None):
         """ Samples from the Luminosity Function nsource times
@@ -395,7 +396,7 @@ class BPL_LuminosityFunction(LuminosityFunction):
             ],
         )
 
-def get_LuminosityFunction(LF_conf):
+def get_LuminosityFunction(mean_luminosity, LF, **kwargs):
     """Returns a Luminosity Function based on a configuration string.
     Supported LFs are:
         - SC - Standard Candle
@@ -404,29 +405,37 @@ def get_LuminosityFunction(LF_conf):
         - BPL - Broken-Power-Law
 
     Args:
-        - LF_conf: string, configuration string for the Luminosity Function. The string contains the LF type and the numerical parameters separated by a semicolon (':').
+        - LF_conf: string, configuration string for the Luminosity Function. 
+          The string contains the LF type.
 
-    String formats:
-        - Standard Candle: 'SC:mean_luminosity'
-        - Log-Normal: 'LG:mean_luminosity:width'
-        - Power-Law: 'PL:Lmin:Lmax:alpha'
-        - Broken Power-Law: 'BPL:Lmin:Lbreak:Lmax:alpha1:alpha2' 
+        - kwargs: The specific arguments for each luminosity function
+          Log-Normal: lg_width
+          Power-Law: pl_lmin, pl_lmax, pl_alpha
+          Broken Power-Law: bpl_lmin, bpl_lbreak, bpl_lmax, bpl_alpha1, bpl_alpha2
 
     Raises 'NotImplementedError' for unknown abbreviation.
     """
 
     # TODO: this would better go into a try-except block
-    LF = LF_conf.split(':')
-    LF_type = LF[0]
-    params = [float(param) for param in LF[1:]]
-
+    LF_type = LF
     if LF_type == "SC":
-        return SC_LuminosityFunction(mean_luminosity=params[0])
+        return SC_LuminosityFunction(mean_luminosity=mean_luminosity, )
     if LF_type == "LG":
-        return LG_LuminosityFunction(mean_luminosity=params[0], width=params[1])
+        width = kwargs.get('lg_width', 1.0)
+        return LG_LuminosityFunction(mean_luminosity=mean_luminosity, 
+                                     width=width)
     if LF_type == "PL":
-        return PL_LuminosityFunction(Lmin=params[0], Lmax=params[1], alpha=params[2])
+        lmin = kwargs.get('pl_lmin')
+        lmax = kwargs.get('pl_lmax')
+        alpha = kwargs.get('pl_alpha')
+        return PL_LuminosityFunction(Lmin=lmin, Lmax=lmax, alpha=alpha)
     if LF_type == "BPL":
-        return BPL_LuminosityFunction(Lmin=params[0], Lbreak=params[1], Lmax=params[2], alpha1=params[3], alpha2=params[4])
+        lmin = kwargs.get('bpl_lmin')
+        lmax = kwargs.get('bpl_lmax')
+        lbreak = kwargs.get('bpl_lbreak')
+        alpha1 = kwargs.get('bpl_alpha1')
+        alpha2 = kwargs.get('bpl_alpha2')
+        return BPL_LuminosityFunction(Lmin=lmin, Lbreak=lbreak, Lmax=lmax, 
+                                      alpha1=alpha1, alpha2=alpha2)
 
     raise NotImplementedError("The luminosity function " + LF + " is not implemented.")

--- a/firesong/Luminosity.py
+++ b/firesong/Luminosity.py
@@ -310,3 +310,25 @@ class BPL_LuminosityFunction(LuminosityFunction):
                 lambda F: self.PL2.inv_F(F - self.PL1.integral),
             ],
         )
+
+
+def get_LuminosityFunction(mean_luminosity, LF, **kwargs):
+    """Returns a Luminosity Function based on an abbreviation.
+    Known abbreviations are:
+        - SC - Standard Candle
+        - LG - Log-Normal
+        - PL - Power-Law
+    Args:
+        - options: Namespace with LF and needed parameters to
+                   construct luminosity function.
+        - mean_luminosity: mean luminosity.
+    Raises 'NotImplementedError' for unknown abbreviation.
+    """
+
+    if LF == "SC":
+        return SC_LuminosityFunction(mean_luminosity)
+    if LF == "LG":
+        return LG_LuminosityFunction(mean_luminosity, kwargs["sigma"])
+    if LF == "PL":
+        return PL_LuminosityFunction(mean_luminosity, kwargs["index"], kwargs["sigma"])
+    raise NotImplementedError("The luminosity function " + LF + " is not implemented.")

--- a/firesong/Luminosity.py
+++ b/firesong/Luminosity.py
@@ -8,13 +8,14 @@ from scipy.stats import lognorm
 
 
 class LuminosityFunction(object):
-    """Luminosity Function class."""
+    """Luminosity Function class.
+    """
 
     def __init__(self, mean_luminosity):
         """Luminosity function.
 
         Args:
-            - mean luminosity (Not median and not log(mean))
+            - mean luminosity (Not not median and not log(mean))
         """
         self.mean = mean_luminosity
 
@@ -29,12 +30,12 @@ class LuminosityFunction(object):
 
 
 class SC_LuminosityFunction(LuminosityFunction):
-    """Standard Candle Luminosity functions.
+    """ Standard Candle Luminosity functions.
     All sources have same luminosity.
     """
 
     def sample_distribution(self, nsources=None, rng=None):
-        """Samples from the Luminosity Function nsource times
+        """ Samples from the Luminosity Function nsource times
 
         Args:
             number of sources
@@ -42,7 +43,7 @@ class SC_LuminosityFunction(LuminosityFunction):
         return self.mean
 
     def pdf(self, lumi):
-        """Gives the value of the PDF at lumi.
+        """ Gives the value of the PDF at lumi.
 
         Args:
             lumi: float or array-like, point where PDF is evaluated.
@@ -53,18 +54,17 @@ class SC_LuminosityFunction(LuminosityFunction):
         """
         lumi = np.atleast_1d(lumi)
         if len(lumi) < 2:
-            raise NotImplementedError(
-                """This is a delta function.
+            raise NotImplementedError("""This is a delta function.
                 PDF not defined.
                 We only can return something meaning full for a nice array.
-                """
-            )
+                """)
         pdf = np.zeros_like(lumi)
-        pdf[:-1][np.logical_and(self.mean > lumi[:-1], self.mean < lumi[1:])] = 1
+        pdf[:-1][np.logical_and(self.mean > lumi[:-1],
+                 self.mean < lumi[1:])] = 1
         return pdf
 
     def cdf(self, lumi):
-        """Gives the value of the CDF at lumi.
+        """ Gives the value of the CDF at lumi.
 
         Args:
             lumi: float or array-like, point where CDF is evaluated.
@@ -76,16 +76,17 @@ class SC_LuminosityFunction(LuminosityFunction):
         """
         lumi = np.atleast_1d(lumi)
         cdf = np.zeros_like(lumi)
-        cdf[lumi == self.mean] = 0.5
-        cdf[lumi > self.mean] = 1.0
+        cdf[lumi == self.mean] = .5
+        cdf[lumi > self.mean] = 1.
         if len(lumi) == 1:
             return cdf[0]
         return cdf
 
 
 class LG_LuminosityFunction(LuminosityFunction):
+
     def __init__(self, mean_luminosity, width):
-        """Log Normal Luminosity function.
+        """ Log Normal Luminosity function.
 
         Args:
             - mean luminosity (Not median and not log(mean))
@@ -98,13 +99,13 @@ class LG_LuminosityFunction(LuminosityFunction):
             sigma = log(10^width)
         """
         self.mean = mean_luminosity
-        self.width = width  # width is given in log10
-        self.logmean = np.log(self.mean)  # log mean luminosity
-        self.sigma = np.log(10**self.width)  # sigma is given in ln
-        self.mu = self.logmean - self.sigma**2.0 / 2.0  # log median luminosity
+        self.width = width                     # width is given in log10
+        self.logmean = np.log(self.mean)       # log mean luminosity
+        self.sigma = np.log(10**self.width)    # sigma is given in ln
+        self.mu = self.logmean-self.sigma**2./2.  # log median luminosity
 
     def sample_distribution(self, nsources=None, rng=None):
-        """Samples from the Luminosity Function nsource times
+        """ Samples from the Luminosity Function nsource times
 
         Args:
             number of sources
@@ -114,7 +115,7 @@ class LG_LuminosityFunction(LuminosityFunction):
         return rng.lognormal(self.mu, self.sigma, nsources)
 
     def pdf(self, lumi):
-        r"""Gives the value of the PDF at lumi.
+        r""" Gives the value of the PDF at lumi.
 
         Args:
             lumi: float or array-like, point where PDF is evaluated.
@@ -122,13 +123,13 @@ class LG_LuminosityFunction(LuminosityFunction):
         Notes:
             PDF given by:
 
-            $$ \frac{1}{x\sigma \sqrt{2\pi}} \times
+            $$ \frac{1}{x\sigma \sqrt{2\pi}} \times 
             \exp{-\frac{(\ln(x)-\mu)^2}{2\sigma^1}}$$
         """
         return lognorm.pdf(lumi, s=self.sigma, scale=np.exp(self.mu))
 
     def cdf(self, lumi):
-        r"""Gives the value of the CDF at lumi.
+        r""" Gives the value of the CDF at lumi.
 
         Args:
             lumi: float or array-like, point where CDF is evaluated.
@@ -136,11 +137,96 @@ class LG_LuminosityFunction(LuminosityFunction):
         Notes:
             CDF given by:
 
-            $$ \frac{1}{2} + \frac{1}{2} \times
+            $$ \frac{1}{2} + \frac{1}{2} \times 
             \mathrm{erf}\left( \frac{(\ln(x)-\mu)^2}{\sqrt{2}\sigma}\right)$$
         """
         return lognorm.cdf(lumi, s=self.sigma, scale=np.exp(self.mu))
 
+
+class PL_LuminosityFunction(LuminosityFunction):
+    r""" Power-law distribution defined between x_min and x_max.
+
+        PDF:
+        $$\frac{1-\alpha}{x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}\times
+        x^{-\alpha}$$
+
+        CDF:
+        $$\frac{x^{1-\alpha}-x_{min}^{1-\alpha}}
+        {x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}$$
+
+        inv.CDF:
+        $$ P^{-1}(x) = (x_{min}^{\beta} + (x_{max}^{\beta}
+         -x_{min}^{\beta})*x)^{1/\beta}$$
+
+        Formulars from: http://up-rs-esp.github.io/bpl/
+        and: Clauset, A., Shalizi, C. R., Newman, M. E. J.
+        "Power-law Distributions in Empirical Data".
+        SFI Working Paper: 2007-12-049 (2007)  arxiv:0706.1062
+    """
+
+    def __init__(self, mean_luminosity, index, width):
+        """ Power-law distribution defined between x_min and x_max.
+        x_min and x_max are calculated from mean and width of distribution.
+
+        Note:
+            f_mean ~= width*ln(10)*F_min,          index = -2
+            f_mean ~= (index+1)/(index+2)*F_min    index < -2
+        """
+        self.mean = mean_luminosity
+        self.index = index
+        self.width = width
+
+        if self.index == -2:
+            self.Fmin = self.mean / (self.width*np.log(10))
+        else:
+            self.Fmin = (self.index+2.)/(self.index+1.)*self.mean
+
+        self.Fmax = self.Fmin*10**self.width
+
+    def sample_distribution(self, nsources=None, rng=None):
+        """Samples from the Luminosity Function nsource times
+
+        Args:
+            number of sources
+        """
+        if rng is None:
+            rng = np.random.RandomState()
+        x = rng.uniform(0, 1, nsources)
+        beta = (1.+self.index)
+        return (self.Fmin**beta + (self.Fmax**beta -
+                                   self.Fmin**beta)*x)**(1./beta)
+
+    def pdf(self, lumi):
+        r"""Gives the value of the PDF at lumi.
+
+        Args:
+            lumi: float or array-like, point where PDF is evaluated.
+
+        Notes:
+            PDF given by:
+            $$\frac{1-\alpha}{x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}
+            \times x^{-\alpha}$$
+        """
+
+        norm = (1+self.index)/(self.Fmax**(1+self.index) -
+                               self.Fmin**(1+self.index))
+        pdf = norm*lumi**self.index
+        pdf[np.logical_or(lumi < self.Fmin, lumi > self.Fmax)] = 0
+        return pdf
+
+    def cdf(self, lumi):
+        r"""Gives the value of the CDF at lumi.
+
+        Args:
+            lumi: float or array-like, point where CDF is evaluated.
+
+        Note:
+            CDF given by:
+            $$\frac{x^{1-\alpha}-x_{min}^{1-\alpha}}
+            {x_{max}^{1-\alpha}-x_{min}^{1-\alpha}}$$
+        """
+        return (lumi**(1+self.index) - self.Fmin**(1+self.index)) / \
+               ((self.Fmax**(1+self.index) - self.Fmin**(1+self.index)))
 
 class BoundedPowerLaw:
     r"""Defines a power law with arbitrary scale in the form:
@@ -265,7 +351,6 @@ class PL_LuminosityFunction(LuminosityFunction):
         """
         return self.PL.inv_F(F)
 
-
 class BPL_LuminosityFunction(LuminosityFunction):
     """
     Broken power law consisting defined between Lmin and Lmax, consisting of two power laws joining at Lbreak.
@@ -311,24 +396,30 @@ class BPL_LuminosityFunction(LuminosityFunction):
             ],
         )
 
-
 def get_LuminosityFunction(mean_luminosity, LF, **kwargs):
     """Returns a Luminosity Function based on an abbreviation.
     Known abbreviations are:
         - SC - Standard Candle
         - LG - Log-Normal
         - PL - Power-Law
+
     Args:
         - options: Namespace with LF and needed parameters to
                    construct luminosity function.
         - mean_luminosity: mean luminosity.
+
     Raises 'NotImplementedError' for unknown abbreviation.
     """
 
     if LF == "SC":
         return SC_LuminosityFunction(mean_luminosity)
     if LF == "LG":
-        return LG_LuminosityFunction(mean_luminosity, kwargs["sigma"])
+        return LG_LuminosityFunction(mean_luminosity,
+                                     kwargs["sigma"])
     if LF == "PL":
-        return PL_LuminosityFunction(mean_luminosity, kwargs["index"], kwargs["sigma"])
+        print("A power-law LF has been selected, ignoring mean luminosity.")
+        return PL_LuminosityFunction(kwargs["alpha"], kwargs["Lmin"], kwargs["Lmax"], )
+    if LF == "BPL":
+        print("A broken power-law LF has been selected, ignoring mean luminosity.")
+        return BPL_LuminosityFunction(kwargs["alpha"], kwargs["Lmin"], kwargs["Lbreak"], kwargs["Lmax"])
     raise NotImplementedError("The luminosity function " + LF + " is not implemented.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 coverage==5.4
-numpy==1.16.6
+numpy==1.22.0
 scipy==1.2.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 long_message = 'FIRESONG: the FIRst Extragalactic Simulation Of Neutrinos and Gamma-rays'
-version = "1.8"
+version = "1.9"
 
 setuptools.setup(
     name="firesong", 
@@ -17,11 +17,11 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
     #'CosmoloPy>=0.4',
     'coverage>=5.4',
-    'numpy>=1.16.6',
+    'numpy>=1.22.0',
     'scipy>=1.2.3',
     ]
 )

--- a/tests/test_FluxPDF.py
+++ b/tests/test_FluxPDF.py
@@ -33,10 +33,10 @@ class TestFluxPDFSimulation(unittest.TestCase):
         cls.lg_flux_pdf = FluxPDF.flux_pdf(None,
             filename=None,
             LF='LG',
-            sigma = 0.01,
             Evolution="MD2014SFR",
             verbose=False,
-            logFMin=-20)
+            logFMin=-20,
+            lg_width=0.01)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_Luminosity.py
+++ b/tests/test_Luminosity.py
@@ -84,7 +84,7 @@ class TestLuminosity(unittest.TestCase):
 
     def test_LG_LuminosityFunction_PDF(self):
         lf = Luminosity.LG_LuminosityFunction(1e50, 1.)
-        self.assertEqual(lf.pdf(1e49), 1.712868408774468e-50)
+        self.assertEqual(lf.pdf(1e49), 1.7128684087744686e-50)
 
     def test_LG_LuminosityFunction_CDF(self):
         lf = Luminosity.LG_LuminosityFunction(1e50, 1.)


### PR DESCRIPTION
1. To address #72, interp1d is now the choice for calculating luminosity distance
2. To address #71 , The way args are passed to luminosity function from firesong_simulation is changed. Now, it's done through some luminosity function specific kwargs, for example, `lg_width` for the width of log normal. The kwargs can also pass arguments to evolution if such need arises. 
3. Switch the setup to use python 3.8 and numpy 1.22 for security reason